### PR TITLE
🔨 npm script to run the library from the terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint src tests --ext .ts",
     "lint:fix": "eslint src tests --ext .ts --fix",
     "prettier": "prettier --check **/*.ts",
-    "prettier:fix": "prettier --write **/*.ts"
+    "prettier:fix": "prettier --write **/*.ts",
+    "cli": "npm run build -- -q && node scripts/cli.js"
   },
   "author": {
     "name": "qd-qd",

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,0 +1,28 @@
+/**
+ * This script can be run from the command line using `npm run cli` in order to precompute
+ * the points of a public key and log the result to the console.s
+ *
+ * Usage: `npm run cli <x> <y>`
+ *
+ * @example
+ * // Precompute the points of a public key with x=123 and y=456
+ * npm run cli 123 456
+ */
+const precomputePoints = require("../dist/index.js").default;
+
+try {
+  // get the arguments passed to the script
+  let [x, y] = process.argv.slice(2);
+
+  // if no arguments are passed, throw an error
+  if (!x || !y)
+    throw new Error(
+      "pass the x and y coordinates of the public key as arguments"
+    );
+
+  // try to convert the arguments to bigint then precompute the points and log the results
+  precomputePoints(BigInt(Number(x)), BigInt(Number(y))).then(console.log);
+} catch (e) {
+  console.error(e);
+  process.exit(1);
+}


### PR DESCRIPTION
This commit adds a new `npm run cli` script that runs the library from the terminal and log the output. Useful to quickly generate the points.