### PR TITLE
👷 setup git hooks using lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-push:
+  parallel: true
+  commands:
+    eslint:
+      tags: quality
+      run: npm run lint
+    prettier:
+      tags: quality
+      run: npm run prettier
+    test:
+      run: npm run test
+    build:
+      run: npm run build
+# @DEV: Use `CI=true` env variable if you want to bypass
+# the execution of the installed hooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@typescript-eslint/parser": "^5.59.8",
         "eslint": "^8.41.0",
         "jest": "^29.5.0",
+        "lefthook": "^1.4.1",
         "prettier": "2.8.8",
         "typescript": "^5.0.4"
       }
@@ -5210,6 +5211,130 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.4.1.tgz",
+      "integrity": "sha512-05jULu8iGCOfUnONImG3MJOtmMG9W1ihlnWWDJ6vmmC6eZqtb4yFBw5Dt/fD0H3ZFeYa9Yb2quvaU3y88W5GCw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.4.1",
+        "lefthook-darwin-x64": "1.4.1",
+        "lefthook-freebsd-arm64": "1.4.1",
+        "lefthook-freebsd-x64": "1.4.1",
+        "lefthook-linux-arm64": "1.4.1",
+        "lefthook-linux-x64": "1.4.1",
+        "lefthook-windows-arm64": "1.4.1",
+        "lefthook-windows-x64": "1.4.1"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.4.1.tgz",
+      "integrity": "sha512-j3Egr/oNu8JKZDtwtKZrU+34c4DDNy8sKuagZrfFpmwhZEqSFUMxjxUC/J8QnX0Bc60Wo+UAUfv/Oe6g+s4QSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.4.1.tgz",
+      "integrity": "sha512-gGzltha7Fo3CDavDUF9l8VVcrMCb8Dm3x/Bax4+Pjs3ZUTTgIxZZe89ORYqVlet0egh9GUx/L20r8+kwdTDwAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.4.1.tgz",
+      "integrity": "sha512-OzpkXzOeRjTjXT+f+AjZxxBhaSA6QTqWMlrkgnFJuNZOVKT6bfgkusvpyC1KAYlKxlRGHnvfTRPAv3Ouub/vaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.4.1.tgz",
+      "integrity": "sha512-6befhXE64XOyt1XLg5Wf1/rVMvwzOf0BaEvQoBXX8fn6/3q1e+86fcejUi4doMngeagpm03XWMqNiy592NqfZw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.4.1.tgz",
+      "integrity": "sha512-j8p2BukrsFAC4fGQVqCFVE6CfwE7d21nh3WUMWqISk8qMO5+OTkdohZViPeOPk9sxxC05aXvFDgWDKW0VXs1og==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.4.1.tgz",
+      "integrity": "sha512-0cYddhIjT8FtrFB47rKLYi7FLmYRi3NRexpyj6FRiTWkN8Joz10MpCqFPnZOfZRPgUm4sg5HqoTdxiDmaYV2kQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.4.1.tgz",
+      "integrity": "sha512-jgY/m6+g9ofr+ePx0tUoo63ItunVBYamCY16wLnXVI6xyYmP5wEy83u0lnBS4wQ8zcH22YUCDrL8KtrQFfLsjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.4.1.tgz",
+      "integrity": "sha512-lvTpayQkBmOp5czolntESM2uWRG0I5r0HkOnFfhGEaqEFm45sUjKZsxNj/EPQLAXlWlXqLe363UNcSnmUf/g3g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "lint:fix": "eslint src tests --ext .ts --fix",
     "prettier": "prettier --check **/*.ts",
     "prettier:fix": "prettier --write **/*.ts",
-    "cli": "npm run build -- -q && node scripts/cli.js"
+    "cli": "npm run build -- -q && node scripts/cli.js",
+    "hooks": "lefthook run pre-push",
+    "hooks:install": "lefthook install",
+    "hooks:uninstall": "lefthook uninstall"
   },
   "author": {
     "name": "qd-qd",
@@ -40,6 +43,7 @@
     "@typescript-eslint/parser": "^5.59.8",
     "eslint": "^8.41.0",
     "jest": "^29.5.0",
+    "lefthook": "^1.4.1",
     "prettier": "2.8.8",
     "typescript": "^5.0.4"
   }


### PR DESCRIPTION
This commit setup lefthook as the git hooks manager of the repository. It allows builders to install the `pre-push` hook that will run the listed commandes before pushing to the remote repository. Additionnaly, I added 3 npm scripts to easily install, uninstall and run the hook.