### PR TITLE
🔖 bump to v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-computation",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-computation",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0x90d2b2b7fb7599eebb6e7a32980857d8/secp256r1-computation",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "This library boosts ECDSA performance by generating a precomputed table of 256 points on the secp256r1 curve from a public key. This optimization speeds up point multiplication, making elliptic curve digital signature algorithms more efficient.",
   "source": "src/index.ts",
   "main": "dist/module.js",


### PR DESCRIPTION
This version exports the library as default. This a breaking change.