### PR TITLE
🚸 make the library cli-friendly

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * This script can be run from the command line using `npm run cli` in order to precompute
  * the points of a public key and log the result to the console.s

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "files": [
     "dist"
   ],
+  "bin": {
+    "comput256r1": "cli.mjs"
+  },
   "keywords": [
     "secp256r1",
     "256r1"
@@ -28,7 +31,6 @@
     "lint:fix": "eslint src tests --ext .ts --fix",
     "prettier": "prettier --check **/*.ts",
     "prettier:fix": "prettier --write **/*.ts",
-    "cli": "npm run build && node scripts/cli.mjs",
     "hooks": "lefthook run pre-push",
     "hooks:install": "lefthook install",
     "hooks:uninstall": "lefthook uninstall"


### PR DESCRIPTION
If I did it well, after the release of this commit, it would be able to run the `cli` script using `npx` once the library is installed globally. If I did it well.